### PR TITLE
fix: docker-compose version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+version: '3.0'
+
 services:
   web:
     build: .


### PR DESCRIPTION
Added version tag to `docker-compose.yaml` file as it was throwing the following error

```sh
ERROR: The Compose file './docker-compose.yaml' is invalid
```
After this fix, users will be able to run `docker-compose [command]` commands
